### PR TITLE
fix: file rename bug

### DIFF
--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -41,7 +41,10 @@ export function loadTracker(json: string): Tracker {
     return {entries: []};
 }
 
-export function displayTracker(tracker: Tracker, element: HTMLElement, file: string, getSectionInfo: () => MarkdownSectionInformation, settings: SimpleTimeTrackerSettings, component: MarkdownRenderChild): void {
+type GetFile = () => string;
+
+export function displayTracker(tracker: Tracker, element: HTMLElement, getFile: GetFile, getSectionInfo: () => MarkdownSectionInformation, settings: SimpleTimeTrackerSettings, component: MarkdownRenderChild): void {
+   
     element.addClass("simple-time-tracker-container");
     // add start/stop controls
     let running = isRunning(tracker);
@@ -55,7 +58,7 @@ export function displayTracker(tracker: Tracker, element: HTMLElement, file: str
             } else {
                 startNewEntry(tracker, newSegmentNameBox.getValue());
             }
-            await saveTracker(tracker, this.app, file, getSectionInfo());
+            await saveTracker(tracker, this.app, getFile(), getSectionInfo());
         });
     btn.buttonEl.addClass("simple-time-tracker-btn");
     let newSegmentNameBox = new TextComponent(element)
@@ -83,7 +86,7 @@ export function displayTracker(tracker: Tracker, element: HTMLElement, file: str
             createEl("th"));
 
         for (let entry of orderedEntries(tracker.entries, settings))
-            addEditableTableRow(tracker, entry, table, newSegmentNameBox, running, file, getSectionInfo, settings, 0, component);
+            addEditableTableRow(tracker, entry, table, newSegmentNameBox, running, getFile, getSectionInfo, settings, 0, component);
 
         // add copy buttons
         let buttons = element.createEl("div", {cls: "simple-time-tracker-bottom"});
@@ -303,7 +306,7 @@ function orderedEntries(entries: Entry[], settings: SimpleTimeTrackerSettings): 
     return settings.reverseSegmentOrder ? entries.slice().reverse() : entries;
 }
 
-function addEditableTableRow(tracker: Tracker, entry: Entry, table: HTMLTableElement, newSegmentNameBox: TextComponent, trackerRunning: boolean, file: string, getSectionInfo: () => MarkdownSectionInformation, settings: SimpleTimeTrackerSettings, indent: number, component: MarkdownRenderChild): void {
+function addEditableTableRow(tracker: Tracker, entry: Entry, table: HTMLTableElement, newSegmentNameBox: TextComponent, trackerRunning: boolean, getFile: GetFile, getSectionInfo: () => MarkdownSectionInformation, settings: SimpleTimeTrackerSettings, indent: number, component: MarkdownRenderChild): void {
     let entryRunning = getRunningEntry(tracker.entries) == entry;
     let row = table.createEl("tr");
 
@@ -313,7 +316,7 @@ function addEditableTableRow(tracker: Tracker, entry: Entry, table: HTMLTableEle
 
     row.createEl("td", {text: entry.endTime || entry.subEntries ? formatDuration(getDuration(entry), settings) : ""});
 
-    renderNameAsMarkdown(nameField.label, file, component);
+    renderNameAsMarkdown(nameField.label, getFile, component);
 
     let entryButtons = row.createEl("td");
     entryButtons.addClass("simple-time-tracker-table-buttons");
@@ -324,7 +327,7 @@ function addEditableTableRow(tracker: Tracker, entry: Entry, table: HTMLTableEle
         .setDisabled(trackerRunning)
         .onClick(async () => {
             startSubEntry(entry, newSegmentNameBox.getValue());
-            await saveTracker(tracker, this.app, file, getSectionInfo());
+            await saveTracker(tracker, this.app, getFile(), getSectionInfo());
         });
     let editButton = new ButtonComponent(entryButtons)
         .setClass("clickable-icon")
@@ -339,10 +342,10 @@ function addEditableTableRow(tracker: Tracker, entry: Entry, table: HTMLTableEle
                     endField.endEdit();
                     entry.endTime = endField.getTimestamp();
                 }
-                await saveTracker(tracker, this.app, file, getSectionInfo());
+                await saveTracker(tracker, this.app, getFile(), getSectionInfo());
                 editButton.setIcon("lucide-pencil");
 
-                renderNameAsMarkdown(nameField.label, file, component);
+                renderNameAsMarkdown(nameField.label, getFile, component);
             } else {
                 nameField.beginEdit(entry.name);
                 // only allow editing start and end times if we don't have sub entries
@@ -361,17 +364,17 @@ function addEditableTableRow(tracker: Tracker, entry: Entry, table: HTMLTableEle
         .setDisabled(entryRunning)
         .onClick(async () => {
             removeEntry(tracker.entries, entry);
-            await saveTracker(tracker, this.app, file, getSectionInfo());
+            await saveTracker(tracker, this.app, getFile(), getSectionInfo());
         });
 
     if (entry.subEntries) {
         for (let sub of orderedEntries(entry.subEntries, settings))
-            addEditableTableRow(tracker, sub, table, newSegmentNameBox, trackerRunning, file, getSectionInfo, settings, indent + 1, component);
+            addEditableTableRow(tracker, sub, table, newSegmentNameBox, trackerRunning, getFile, getSectionInfo, settings, indent + 1, component);
     }
 }
 
-function renderNameAsMarkdown(label: HTMLSpanElement, path: string, component: Component): void {
-    void MarkdownRenderer.renderMarkdown(label.innerHTML, label, path, component);
+function renderNameAsMarkdown(label: HTMLSpanElement, getFile: GetFile, component: Component): void {
+    void MarkdownRenderer.renderMarkdown(label.innerHTML, label, getFile(), component);
     // rendering wraps it in a paragraph
     label.innerHTML = label.querySelector("p").innerHTML;
 }


### PR DESCRIPTION
## Description 

Hey! I've been building out a similar time tracker more tailored to my needs. Using the same storage medium of code blocks as you. I've just patched a bug in mine that I'd been searching for a while but could never figure out why it was happening.

The bug is what was a seemingly random failure to save the time tracking data (Although now I realize it was very much not random)

The bug is caused by the file name changing and the tracker not realizing and trying to modify the old file that doesn't exist. As often I renamed the file before stopping my tracker for the day and thus I encountered this bug.

## How to reproduce

1. Open a file and create a time tracker
2. Start the timer 
3. Rename the file (Using the editable title in Obsidian)
4. Stop the timer
5. Bam saving silently fails (If you close and open the file again you'll see the timer wasn't stopped)

## The fix

The fix I came up with for my plugin was to use `vault.on` with the "rename" event to update the file path that i'm saving to  the code for that looks a little something like this:

I've modified your code slightly to pass the file name using a function that is called whenever you save the tracker that way its always the latest value which is being obtained through the rename event