### PR TITLE
feat: Implement collapsing nested subentries

### DIFF
--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -357,9 +357,7 @@ function addEditableTableRow(tracker: Tracker, entry: Entry, table: HTMLTableEle
         .onClick(async () => {
             if (nameField.editing()) {
                 entry.name = nameField.endEdit();
-                if (entry.subEntries?.length) {
-                    expandButton.buttonEl.style.display = null;
-                }
+                expandButton.buttonEl.style.display = null;
                 startField.endEdit();
                 entry.startTime = startField.getTimestamp();
                 if (!entryRunning) {
@@ -372,9 +370,7 @@ function addEditableTableRow(tracker: Tracker, entry: Entry, table: HTMLTableEle
                 renderNameAsMarkdown(nameField.label, getFile, component);
             } else {
                 nameField.beginEdit(entry.name);
-                if (entry.subEntries?.length) {
-                    expandButton.buttonEl.style.display = 'none';
-                }
+                expandButton.buttonEl.style.display = 'none';
                 // only allow editing start and end times if we don't have sub entries
                 if (!entry.subEntries) {
                     startField.beginEdit(entry.startTime);

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -333,11 +333,7 @@ function addEditableTableRow(tracker: Tracker, entry: Entry, table: HTMLTableEle
             await saveTracker(tracker, this.app, getFile(), getSectionInfo());
         });
     if (!entry.subEntries?.length) expandButton.buttonEl.style.visibility = 'hidden';
-    let nameWrapper = nameField.cell.createDiv({cls: "simple-time-tracker-table-expandwrapper"});
-    nameWrapper.style.marginLeft = nameField.label.style.marginLeft;
-    nameField.label.style.marginLeft = null;
-    nameWrapper.insertBefore(expandButton.buttonEl, null);
-    nameWrapper.insertBefore(nameField.label, null);
+    nameField.cell.insertBefore(expandButton.buttonEl, nameField.label);
 
     let entryButtons = row.createEl("td");
     entryButtons.addClass("simple-time-tracker-table-buttons");

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -10,7 +10,7 @@ export interface Entry {
     startTime: string;
     endTime: string;
     subEntries: Entry[];
-    collapsed?: number;
+    collapsed?: boolean;
 }
 
 export async function saveTracker(tracker: Tracker, app: App, fileName: string, section: MarkdownSectionInformation): Promise<void> {
@@ -328,7 +328,7 @@ function addEditableTableRow(tracker: Tracker, entry: Entry, table: HTMLTableEle
             if (entry.collapsed) {
                 delete entry.collapsed;
             } else {
-                entry.collapsed = 1;
+                entry.collapsed = true;
             }
             await saveTracker(tracker, this.app, getFile(), getSectionInfo());
         });

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -324,7 +324,7 @@ function addEditableTableRow(tracker: Tracker, entry: Entry, table: HTMLTableEle
             .setClass("clickable-icon")
             .setClass("simple-time-tracker-expand-button")
             .setIcon(`chevron-${entry.collapsed ? 'right' : 'down'}`)
-            .setTooltip("Collapse")
+            .setTooltip(entry.collapsed ? "Expand" : "Collapse")
             .onClick(async () => {
                 if (entry.collapsed) {
                     delete entry.collapsed;

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -10,6 +10,7 @@ export interface Entry {
     startTime: string;
     endTime: string;
     subEntries: Entry[];
+    collapsed?: number;
 }
 
 export async function saveTracker(tracker: Tracker, app: App, fileName: string, section: MarkdownSectionInformation): Promise<void> {
@@ -318,6 +319,27 @@ function addEditableTableRow(tracker: Tracker, entry: Entry, table: HTMLTableEle
 
     renderNameAsMarkdown(nameField.label, getFile, component);
 
+    if (entry.subEntries?.length) {
+        let expandButton = new ButtonComponent(nameField.label)
+            .setClass("clickable-icon")
+            .setClass("simple-time-tracker-expand-button")
+            .setIcon(`chevron-${entry.collapsed ? 'right' : 'down'}`)
+            .setTooltip("Collapse")
+            .onClick(async () => {
+                if (entry.collapsed) {
+                    delete entry.collapsed;
+                } else {
+                    entry.collapsed = 1;
+                }
+                await saveTracker(tracker, this.app, getFile(), getSectionInfo());
+            });
+        let nameWrapper = nameField.cell.createDiv({cls: "simple-time-tracker-table-expandwrapper"});
+        nameWrapper.style.marginLeft = nameField.label.style.marginLeft;
+        nameField.label.style.marginLeft = null;
+        nameWrapper.insertBefore(nameField.label, null);
+        nameWrapper.insertBefore(expandButton.buttonEl, null);
+    }
+
     let entryButtons = row.createEl("td");
     entryButtons.addClass("simple-time-tracker-table-buttons");
     new ButtonComponent(entryButtons)
@@ -370,7 +392,7 @@ function addEditableTableRow(tracker: Tracker, entry: Entry, table: HTMLTableEle
             await saveTracker(tracker, this.app, getFile(), getSectionInfo());
         });
 
-    if (entry.subEntries) {
+    if (entry.subEntries && !entry.collapsed) {
         for (let sub of orderedEntries(entry.subEntries, settings))
             addEditableTableRow(tracker, sub, table, newSegmentNameBox, trackerRunning, getFile, getSectionInfo, settings, indent + 1, component);
     }

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -319,26 +319,25 @@ function addEditableTableRow(tracker: Tracker, entry: Entry, table: HTMLTableEle
 
     renderNameAsMarkdown(nameField.label, getFile, component);
 
-    if (entry.subEntries?.length) {
-        let expandButton = new ButtonComponent(nameField.label)
-            .setClass("clickable-icon")
-            .setClass("simple-time-tracker-expand-button")
-            .setIcon(`chevron-${entry.collapsed ? 'right' : 'down'}`)
-            .setTooltip(entry.collapsed ? "Expand" : "Collapse")
-            .onClick(async () => {
-                if (entry.collapsed) {
-                    delete entry.collapsed;
-                } else {
-                    entry.collapsed = 1;
-                }
-                await saveTracker(tracker, this.app, getFile(), getSectionInfo());
-            });
-        let nameWrapper = nameField.cell.createDiv({cls: "simple-time-tracker-table-expandwrapper"});
-        nameWrapper.style.marginLeft = nameField.label.style.marginLeft;
-        nameField.label.style.marginLeft = null;
-        nameWrapper.insertBefore(nameField.label, null);
-        nameWrapper.insertBefore(expandButton.buttonEl, null);
-    }
+    let expandButton = new ButtonComponent(nameField.label)
+        .setClass("clickable-icon")
+        .setClass("simple-time-tracker-expand-button")
+        .setIcon(`chevron-${entry.collapsed ? 'right' : 'down'}`)
+        .setTooltip(entry.collapsed ? "Expand" : "Collapse")
+        .onClick(async () => {
+            if (entry.collapsed) {
+                delete entry.collapsed;
+            } else {
+                entry.collapsed = 1;
+            }
+            await saveTracker(tracker, this.app, getFile(), getSectionInfo());
+        });
+    if (!entry.subEntries?.length) expandButton.buttonEl.style.visibility = 'hidden';
+    let nameWrapper = nameField.cell.createDiv({cls: "simple-time-tracker-table-expandwrapper"});
+    nameWrapper.style.marginLeft = nameField.label.style.marginLeft;
+    nameField.label.style.marginLeft = null;
+    nameWrapper.insertBefore(expandButton.buttonEl, null);
+    nameWrapper.insertBefore(nameField.label, null);
 
     let entryButtons = row.createEl("td");
     entryButtons.addClass("simple-time-tracker-table-buttons");
@@ -358,6 +357,9 @@ function addEditableTableRow(tracker: Tracker, entry: Entry, table: HTMLTableEle
         .onClick(async () => {
             if (nameField.editing()) {
                 entry.name = nameField.endEdit();
+                if (entry.subEntries?.length) {
+                    expandButton.buttonEl.style.display = null;
+                }
                 startField.endEdit();
                 entry.startTime = startField.getTimestamp();
                 if (!entryRunning) {
@@ -370,6 +372,9 @@ function addEditableTableRow(tracker: Tracker, entry: Entry, table: HTMLTableEle
                 renderNameAsMarkdown(nameField.label, getFile, component);
             } else {
                 nameField.beginEdit(entry.name);
+                if (entry.subEntries?.length) {
+                    expandButton.buttonEl.style.display = 'none';
+                }
                 // only allow editing start and end times if we don't have sub entries
                 if (!entry.subEntries) {
                     startField.beginEdit(entry.startTime);

--- a/styles.css
+++ b/styles.css
@@ -79,20 +79,3 @@
 .simple-time-tracker-table tr:hover {
     background-color: var(--background-modifier-hover);
 }
-
-.simple-time-tracker-table :is(td,th):first-child {
-    /* HACKY hardcoded 2em to make room for expand/collapse button */
-    padding-left: 2em;
-}
-
-.simple-time-tracker-table-expandwrapper {
-    position: relative;
-}
-
-.simple-time-tracker-expand-button {
-    position: absolute;
-    /* HACKY there should be a better way to position this */
-    left: 0;
-    top: 50%;
-    transform: translate(-100%, -50%);
-}

--- a/styles.css
+++ b/styles.css
@@ -79,3 +79,20 @@
 .simple-time-tracker-table tr:hover {
     background-color: var(--background-modifier-hover);
 }
+
+.simple-time-tracker-table :is(td,th):first-child {
+    /* HACKY hardcoded 2em to make room for expand/collapse button */
+    padding-left: 2em;
+}
+
+.simple-time-tracker-table-expandwrapper {
+    position: relative;
+}
+
+.simple-time-tracker-expand-button {
+    position: absolute;
+    /* HACKY there should be a better way to position this */
+    left: 0;
+    top: 50%;
+    transform: translate(-100%, -50%);
+}


### PR DESCRIPTION
This is with regards to issue #23 .

The main feature set is implemented, with a brief demo [here](https://github.com/Ellpeck/ObsidianSimpleTimeTracker/assets/32316305/7fe98d2b-cc3d-44d0-bdad-202731da7bf1).

As of now I am just always adding 2em of space for the button before each row, regardless of whether there will be any buttons there or not.
Mainly I was trying to preserve the alignment of elements in the same indentation whether they have a button or not, but if anyone wants to suggest a better way to format this that would be welcome.