### PR TITLE
fix: confirm modal breaks cursor

### DIFF
--- a/src/confirm-modal.ts
+++ b/src/confirm-modal.ts
@@ -1,0 +1,53 @@
+import { App, Modal, Setting } from "obsidian";
+
+export class ConfirmModal extends Modal {
+	// Message to show in the modal
+	message: string;
+
+	// Callback to run on user choice
+	callback: (choice: boolean) => void;
+
+	// Whether an option was picked
+	picked: boolean;
+
+	constructor(
+		app: App,
+		message: string,
+		callback: (choice: boolean) => void
+	) {
+		super(app);
+		this.message = message;
+		this.callback = callback;
+	}
+
+	onOpen(): void {
+		const { contentEl } = this;
+		contentEl.createEl("p", { text: this.message });
+
+		new Setting(contentEl)
+			.addButton((btn) =>
+				btn
+					.setButtonText("Ok")
+					.setCta()
+					.onClick(() => {
+						this.picked = true;
+						this.close();
+						this.callback(true);
+					})
+			)
+			.addButton((btn) =>
+				btn.setButtonText("Cancel").onClick(() => {
+					this.picked = true;
+					this.close();
+					this.callback(false);
+				})
+			);
+	}
+
+	onClose(): void {
+		if (!this.picked) {
+			console.log("Fallback");
+			this.callback(false);
+		}
+	}
+}

--- a/src/confirm-modal.ts
+++ b/src/confirm-modal.ts
@@ -10,11 +10,7 @@ export class ConfirmModal extends Modal {
 	// Whether an option was picked
 	picked: boolean;
 
-	constructor(
-		app: App,
-		message: string,
-		callback: (choice: boolean) => void
-	) {
+	constructor(app: App, message: string, callback: (choice: boolean) => void) {
 		super(app);
 		this.message = message;
 		this.callback = callback;
@@ -46,7 +42,6 @@ export class ConfirmModal extends Modal {
 
 	onClose(): void {
 		if (!this.picked) {
-			console.log("Fallback");
 			this.callback(false);
 		}
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,7 @@ export default class SimpleTimeTrackerPlugin extends Plugin {
             // Register the event to remove on unload
             component.registerEvent(renameEventRef);
 
-            displayTracker(tracker, e, getFile, () => i.getSectionInfo(e), this.settings, component);
+            displayTracker(this.app, tracker, e, getFile, () => i.getSectionInfo(e), this.settings, component);
             i.addChild(component)
         });
 


### PR DESCRIPTION
## Description

Fixes some weird behavior with the native confirm dialog that prevents the obsidian editor from working after one is shown (Unless you click another window then click back)

## Changes

- Adds an obsidian modal for confirmations
- Replaces usage of confirm with the custom modal

## Related issues
- Closes #49 