### PR TITLE
feat: maintain indent in "Copy as Table" and "Copy as CSV" exports for sub-entries

### DIFF
--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -358,17 +358,33 @@ function updateLegacyInfo(entries: Entry[]): void {
     }
 }
 
+/**
+ * Recursively generates a table section for the time tracker entries, maintaining the hierarchy
+ * and indenting sub-entries with a dynamic prefix.
+ *
+ * @param entry - The current time tracker entry to process. It may contain nested sub-entries.
+ * @param settings - The settings object for the SimpleTimeTracker, containing format options.
+ * @param indent - The current indentation level, starting at 0 for top-level entries and increasing for sub-entries.
+ *                 This value determines the prefix (e.g., "-", "--") added to sub-entry names.
+ */
+function createTableSection(entry: Entry, settings: SimpleTimeTrackerSettings, indent: number = 0): string[][] {
+    // Create dynamic prefix for sub-entries.
+    const prefix = `${"-".repeat(indent)} `;
 
-function createTableSection(entry: Entry, settings: SimpleTimeTrackerSettings): string[][] {
+    // Generate the table data.
     let ret = [[
-        entry.name,
+        `${prefix}${entry.name}`, // Add prefix based on the indent level.
         entry.startTime ? formatTimestamp(entry.startTime, settings) : "",
         entry.endTime ? formatTimestamp(entry.endTime, settings) : "",
-        entry.endTime || entry.subEntries ? formatDuration(getDuration(entry), settings) : ""]];
+        entry.endTime || entry.subEntries ? formatDuration(getDuration(entry), settings) : ""
+    ]];
+
+    // If sub-entries exist, add them recursively.
     if (entry.subEntries) {
         for (let sub of orderedEntries(entry.subEntries, settings))
-            ret.push(...createTableSection(sub, settings));
+            ret.push(...createTableSection(sub, settings, indent + 1));
     }
+
     return ret;
 }
 


### PR DESCRIPTION
Enhanced the `createTableSection` function to include dynamic prefixing based on the indentation level, ensuring the hierarchical structure of sub-entries is preserved. Each sub-entry level now includes an additional `-` prefix, improving readability in both "Copy as Table" and "Copy as CSV" exports.

This feature resolves issue #22.

initial test table:
![image](https://github.com/user-attachments/assets/470f84d6-3d26-4bff-85b0-3e69b04d4197)

result:
![image](https://github.com/user-attachments/assets/e5113837-ea18-43af-bc70-fceec4fadf04)
