### PR TITLE
New setting to select a command to be triggered when tracker stops

### DIFF
--- a/src/CommandSuggestModal.ts
+++ b/src/CommandSuggestModal.ts
@@ -1,0 +1,37 @@
+import { App, SuggestModal } from "obsidian";
+
+interface CommandOption {
+    id: string;
+    name: string;
+}
+
+export class CommandSuggestModal extends SuggestModal<CommandOption> {
+    private onChoose: (command: CommandOption) => void;
+
+    constructor(app: App, onChoose: (command: CommandOption) => void) {
+        super(app);
+        this.onChoose = onChoose;
+    }
+
+    getSuggestions(query: string): CommandOption[] {
+        const commands = Object.values((this.app as any).commands.commands).map(
+            (cmd: any) => ({ id: cmd.id, name: cmd.name })
+        );
+        return commands.filter(
+            (cmd) =>
+                cmd.name.toLowerCase().includes(query.toLowerCase()) ||
+                cmd.id.toLowerCase().includes(query.toLowerCase())
+        );
+    }
+
+    renderSuggestion(command: CommandOption, el: HTMLElement) {
+        el.createEl("div", { text: `${command.name} (${command.id})` });
+    }
+
+    onChooseSuggestion(
+        command: CommandOption,
+        evt: MouseEvent | KeyboardEvent
+    ) {
+        this.onChoose(command);
+    }
+}

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -1,6 +1,7 @@
 import { App, PluginSettingTab, Setting } from "obsidian";
 import SimpleTimeTrackerPlugin from "./main";
 import { defaultSettings } from "./settings";
+import { CommandSuggestModal } from "./CommandSuggestModal";
 
 export class SimpleTimeTrackerSettingsTab extends PluginSettingTab {
 
@@ -82,6 +83,24 @@ export class SimpleTimeTrackerSettingsTab extends PluginSettingTab {
                 t.onChange(async v => {
                     this.plugin.settings.showToday = v;
                     await this.plugin.saveSettings();
+                });
+            });
+        
+        new Setting(this.containerEl)
+            .setName("Tracker End Command")
+            .setDesc("Select the command to execute when a tracker is ended.")
+            .addButton((button) => {
+                button.setButtonText(
+                    this.plugin.settings.trackerEndCommand
+                        ? this.plugin.settings.trackerEndCommand
+                        : "Select Command"
+                );
+                button.onClick(() => {
+                    new CommandSuggestModal(this.app, (command) => {
+                        this.plugin.settings.trackerEndCommand = command.id;
+                        button.setButtonText(`${command.name}`);
+                        this.plugin.saveSettings();
+                    }).open();
                 });
             });
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,6 +6,7 @@ export const defaultSettings: SimpleTimeTrackerSettings = {
     reverseSegmentOrder: false,
     timestampDurations: false,
     showToday: false,
+    trackerEndCommand: "",
 };
 
 export interface SimpleTimeTrackerSettings {
@@ -17,4 +18,5 @@ export interface SimpleTimeTrackerSettings {
     reverseSegmentOrder: boolean;
     timestampDurations: boolean;
     showToday: boolean;
+    trackerEndCommand: string;
 }

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -85,6 +85,12 @@ export function displayTracker(tracker: Tracker, element: HTMLElement, getFile: 
                 startNewEntry(tracker, newSegmentNameBox.getValue());
             }
             await saveTracker(tracker, getFile(), getSectionInfo());
+            if (running) {
+                const commandId = settings.trackerEndCommand;
+                if (commandId) {
+                    (app as any).commands.executeCommandById(commandId);
+                }
+            }
         });
     btn.buttonEl.addClass("simple-time-tracker-btn");
     let newSegmentNameBox = new TextComponent(element)


### PR DESCRIPTION
This might be useful to automate some routines that are triggered every time the tacker registers a new entry.

In my particular case, I'm developing a plugin that works with the ObsidianSimpleTimeTracker plugin, which needs to be updated every time a new time track entry is registered.

![image](https://github.com/user-attachments/assets/65e209af-47b3-499d-b240-90b3020c1400)
