### PR TITLE
feat: added api.getTotalDurationDate method

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,13 @@
 import {MarkdownRenderChild, Plugin, TFile} from "obsidian";
 import {defaultSettings, SimpleTimeTrackerSettings} from "./settings";
 import {SimpleTimeTrackerSettingsTab} from "./settings-tab";
-import {displayTracker, Entry, formatDuration, formatTimestamp, getDuration, getDurationToday, getRunningEntry, getTotalDuration, getTotalDurationToday, isRunning, loadAllTrackers, loadTracker, orderedEntries} from "./tracker";
+import {displayTracker, Entry, formatDuration, formatTimestamp, getDuration, getDurationToday, getRunningEntry, getTotalDuration, getTotalDurationToday, isRunning, loadAllTrackers, loadTracker, orderedEntries, getTotalDurationDate} from "./tracker";
 
 export default class SimpleTimeTrackerPlugin extends Plugin {
 
     public api = {
         // verbatim versions of the functions found in tracker.ts with the same parameters
-        loadTracker, getDuration, getTotalDuration, getDurationToday, getTotalDurationToday, getRunningEntry, isRunning,
+        loadTracker, getDuration, getTotalDuration, getDurationToday, getTotalDurationToday, getRunningEntry, isRunning, getTotalDurationDate,
 
         // modified versions of the functions found in tracker.ts, with the number of required arguments reduced
         loadAllTrackers: (fileName: string) => loadAllTrackers(this.app, fileName),

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -160,26 +160,32 @@ export function getDuration(entry: Entry): number {
     }
 }
 
+export function getDurationDate(entry: Entry, date: string): number {
+    if (entry.subEntries) return getTotalDurationDate(entry.subEntries, date);
+    if (!entry.startTime) return 0;
+
+    let endTime = entry.endTime ? moment(entry.endTime) : moment();
+    let startTime = moment(entry.startTime);
+
+    const endDayEnd = endTime.clone().endOf("day");
+    const startDayStart = startTime.clone().startOf("day");
+
+    const targetDayStart = moment(date).startOf("day");
+    const targetDayEnd = moment(date).endOf("day");
+
+    const timeFramesDoNotOverlap =
+        endTime.isBefore(targetDayStart) || startDayStart.isAfter(targetDayEnd);
+    if (timeFramesDoNotOverlap) return 0;
+
+    if (startTime.isBefore(targetDayStart)) startTime = targetDayStart;
+    if (endDayEnd.isAfter(targetDayEnd)) endTime = targetDayEnd;
+
+    return endTime.diff(startTime);
+}
+
 export function getDurationToday(entry: Entry): number {
-    if (entry.subEntries) {
-        return getTotalDurationToday(entry.subEntries);
-    } else if (!entry.startTime) {
-        return 0;
-    } else {
-        let today = moment().startOf("day");
-        let endTime = entry.endTime ? moment(entry.endTime) : moment();
-        let startTime = moment(entry.startTime);
-
-        if (endTime.isBefore(today)) {
-            return 0;
-        }
-
-        if (startTime.isBefore(today)) {
-            startTime = today;
-        }
-
-        return endTime.diff(startTime);
-    }
+    const today = moment().format('YYYY-MM-DD');
+    return getDurationDate(entry, today);
 }
 
 export function getTotalDuration(entries: Entry[]): number {
@@ -193,6 +199,13 @@ export function getTotalDurationToday(entries: Entry[]): number {
     let ret = 0;
     for (let entry of entries)
         ret += getDurationToday(entry);
+    return ret;
+}
+
+export function getTotalDurationDate(entries: Entry[], date: string): number {
+    let ret = 0;
+    for (let entry of entries)
+        ret += getDurationDate(entry, date);
     return ret;
 }
 

--- a/test-vault/2026-06-15.md
+++ b/test-vault/2026-06-15.md
@@ -1,0 +1,31 @@
+>[!summary] Daily Note Sum Demo
+> Below is a dataviewjs block showing how to combine with a daily note.
+> the script pulls the date from the filename in order to calculate the totals via `getDurationDate` function
+
+```dataviewjs
+// get the time tracker plugin api instance
+let api = dv.app.plugins.plugins["simple-time-tracker"].api;
+const filename = dv.current().file.name
+
+let totalTracked = 0
+let rows = []
+
+for (let page of dv.pages()) {
+    // load trackers in the file with the given path
+    let trackers = await api.loadAllTrackers(page.file.path);
+
+    if (!trackers.length) continue;
+
+    for (let { section, tracker } of trackers) {
+        // print the total duration of the tracker
+        let duration = api.getTotalDurationDate(tracker.entries, filename);
+        totalTracked += duration;
+        if(duration > 0){
+	        rows.push([page.file.link,api.formatDuration(duration)])
+	    }
+    }
+}
+dv.el("p", "Total Tracked: " + api.formatDuration(totalTracked));
+
+dv.table(['Note', 'Time'], rows);
+```

--- a/test-vault/dataview-test-date-sums.md
+++ b/test-vault/dataview-test-date-sums.md
@@ -1,0 +1,31 @@
+```dataviewjs
+// get the time tracker plugin api instance
+let api = dv.app.plugins.plugins["simple-time-tracker"].api;
+
+for (let page of dv.pages()) {
+    // load trackers in the file with the given path
+    let trackers = await api.loadAllTrackers(page.file.path);
+
+    if (!trackers.length) continue;
+
+    for (let { section, tracker } of trackers) {
+        // print the total duration of the tracker
+        let duration = api.getTotalDurationDate(tracker.entries, '1811-11-11');
+        if(duration > 0){
+	        dv.el("p", page.file.link);
+	        dv.el("p", api.formatDuration(duration));  
+	    }
+    }
+}
+```
+
+
+```simple-time-tracker
+{"entries":[{"name":"Segment 1","startTime":"1811-11-11T11:40:44.000Z","endTime":"1811-11-11T18:40:44.000Z"},{"name":"Segment 2","startTime":"2026-06-16T21:37:24.015Z","endTime":"2026-06-16T21:37:27.887Z"}]}
+```
+
+```simple-time-tracker
+{"entries":[{"name":"Segment 1","startTime":"1811-11-10T11:40:44.000Z","endTime":"1811-11-14T18:40:44.000Z"}]}
+```
+
+

--- a/test-vault/dataview-test.md
+++ b/test-vault/dataview-test.md
@@ -16,3 +16,27 @@ for(let page of dv.pages()) {
 	}
 }
 ```
+
+
+
+```dataviewjs
+// get the time tracker plugin api instance
+let api = dv.app.plugins.plugins["simple-time-tracker"].api;
+
+for (let page of dv.pages()) {
+    // load trackers in the file with the given path
+    let trackers = await api.loadAllTrackers(page.file.path);
+
+    if (!trackers.length) continue;
+
+    for (let { section, tracker } of trackers) {
+        // print the total duration of the tracker
+        let duration = api.getTotalDurationToday(tracker.entries);
+        if(duration > 0){
+	        dv.el("p", page.file.link);
+	        dv.el("p", api.formatDuration(duration));  
+	    }
+    }
+}
+```
+

--- a/test-vault/test2.md
+++ b/test-vault/test2.md
@@ -14,3 +14,10 @@ test
 ```simple-time-tracker
 {"entries":[{"name":"Segment 1","startTime":"2026-01-16T14:23:40.894Z","endTime":null}]}
 ```
+
+
+```simple-time-tracker
+{"entries":[{"name":"Segment 1","startTime":"2026-06-15T14:23:40.000Z","endTime":"2026-06-15T20:36:58.000Z"}]}
+```
+
+


### PR DESCRIPTION
Added an api function `api.getTotalDurationDate` to get the sum of a certain day.
Refactored the `getDurationToday` to use the new function with the current date

This enables the User to put for instace a daily summary of tracked hours inside a daily note (see example in test-vault)

hope you like it 😊