### PR TITLE
Omit null timestamps from tracker JSON

### DIFF
--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -8,8 +8,8 @@ export interface Tracker {
 
 export interface Entry {
     name: string;
-    startTime: string;
-    endTime: string;
+    startTime?: string;
+    endTime?: string;
     subEntries?: Entry[];
     collapsed?: boolean;
 }
@@ -295,19 +295,19 @@ function startSubEntry(entry: Entry, name: string): void {
     // if this entry is not split yet, we add its time as a sub-entry instead
     if (!entry.subEntries) {
         entry.subEntries = [{ ...entry, name: `Part 1` }];
-        entry.startTime = null;
-        entry.endTime = null;
+        entry.startTime = undefined;
+        entry.endTime = undefined;
     }
 
     if (!name)
         name = `Part ${entry.subEntries.length + 1}`;
-    entry.subEntries.push({ name: name, startTime: moment().toISOString(), endTime: null, subEntries: undefined });
+    entry.subEntries.push({ name: name, startTime: moment().toISOString() });
 }
 
 function startNewEntry(tracker: Tracker, name: string): void {
     if (!name)
         name = `Segment ${tracker.entries.length + 1}`;
-    let entry: Entry = { name: name, startTime: moment().toISOString(), endTime: null, subEntries: undefined };
+    let entry: Entry = { name: name, startTime: moment().toISOString() };
     tracker.entries.push(entry);
 }
 
@@ -359,6 +359,11 @@ function unformatEditableTimestamp(formatted: string, settings: SimpleTimeTracke
 
 function updateLegacyInfo(entries: Entry[]): void {
     for (let entry of entries) {
+        if (entry.startTime == null)
+            entry.startTime = undefined;
+        if (entry.endTime == null)
+            entry.endTime = undefined;
+
         // in 0.1.8, timestamps were changed from unix to iso
         if (entry.startTime && !isNaN(+entry.startTime))
             entry.startTime = moment.unix(+entry.startTime).toISOString();
@@ -626,11 +631,11 @@ class EditableTimestampField extends EditableField {
         return value;
     }
 
-    getTimestamp(): string {
+    getTimestamp(): string | undefined {
         if (this.box.getValue()) {
             return unformatEditableTimestamp(this.box.getValue(), this.settings);
         } else {
-            return null;
+            return undefined;
         }
     }
 }


### PR DESCRIPTION
## Summary

- make entry timestamps optional so absent values are omitted from serialized tracker JSON
- normalize legacy `null` timestamps while loading existing trackers
- avoid adding `null` values when starting or editing entries

This keeps existing tracker behavior while preventing empty timestamps from accumulating in the JSON.

Closes #89.

## Validation

- `node esbuild.config.mjs production`
- TypeScript 5.9.3: `tsc --noEmit --skipLibCheck`
- exercised `loadTracker()` with nested running and completed entries and confirmed `JSON.stringify()` contains no `null` timestamps while preserving completed timestamps
- `git diff --check`

## Build note

The repository's pinned TypeScript 4.4 compiler cannot currently parse type declarations pulled in through the latest Obsidian dependencies. The resulting `npm run build` errors are limited to `node_modules`; the production esbuild bundle and the source type check with a current TypeScript compiler both pass.
