### PR TITLE
New Features: reorder sections by dragging, and start segment on Enter key

### DIFF
--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -1,4 +1,4 @@
-import {moment, MarkdownSectionInformation, ButtonComponent, TextComponent, TFile, MarkdownRenderer, Component, MarkdownRenderChild, App} from "obsidian";
+import {moment, MarkdownSectionInformation, ButtonComponent, TextComponent, TFile, MarkdownRenderer, Component, MarkdownRenderChild, App, setIcon} from "obsidian";
 import {SimpleTimeTrackerSettings} from "./settings";
 import {ConfirmModal} from "./confirm-modal";
 
@@ -129,8 +129,63 @@ export function displayTracker(app: App, tracker: Tracker, element: HTMLElement,
             createEl("th", { text: "Duration" }),
             createEl("th"));
 
-        for (let entry of orderedEntries(tracker.entries, settings))
-            addEditableTableRow(app, tracker, entry, table, newSegmentNameBox, running, getFile, getSectionInfo, settings, 0, component);
+        let displayed = orderedEntries(tracker.entries, settings);
+        let dragSourceIndex: number | null = null;
+
+        for (let i = 0; i < displayed.length; i++) {
+            let row = addEditableTableRow(app, tracker, displayed[i], table, newSegmentNameBox, running, getFile, getSectionInfo, settings, 0, component);
+            row.setAttribute("data-display-index", String(i));
+            row.draggable = true;
+
+            row.addEventListener("dragstart", (e) => {
+                dragSourceIndex = i;
+                row.addClass("simple-time-tracker-row-dragging");
+                e.dataTransfer.effectAllowed = "move";
+            });
+            row.addEventListener("dragend", () => {
+                row.removeClass("simple-time-tracker-row-dragging");
+                table.querySelectorAll(".simple-time-tracker-row-drop-before, .simple-time-tracker-row-drop-after")
+                    .forEach(el => {
+                        el.removeClass("simple-time-tracker-row-drop-before");
+                        el.removeClass("simple-time-tracker-row-drop-after");
+                    });
+            });
+            row.addEventListener("dragover", (e) => {
+                e.preventDefault();
+                e.dataTransfer.dropEffect = "move";
+                let rect = row.getBoundingClientRect();
+                let dropAfter = e.clientY > rect.top + rect.height / 2;
+                row.dataset.dropAfter = String(dropAfter);
+                table.querySelectorAll(".simple-time-tracker-row-drop-before, .simple-time-tracker-row-drop-after")
+                    .forEach(el => {
+                        el.removeClass("simple-time-tracker-row-drop-before");
+                        el.removeClass("simple-time-tracker-row-drop-after");
+                    });
+                row.addClass(dropAfter ? "simple-time-tracker-row-drop-after" : "simple-time-tracker-row-drop-before");
+            });
+            row.addEventListener("drop", async (e) => {
+                e.preventDefault();
+                if (dragSourceIndex === null || dragSourceIndex === i) return;
+
+                let insertAfter = row.dataset.dropAfter === "true";
+                let sourceEntry = displayed[dragSourceIndex];
+                let targetEntry = displayed[i];
+
+                tracker.entries.splice(tracker.entries.indexOf(sourceEntry), 1);
+                let targetIndex = tracker.entries.indexOf(targetEntry);
+
+                let spliceIndex: number;
+                if (settings.reverseSegmentOrder) {
+                    spliceIndex = insertAfter ? targetIndex : targetIndex + 1;
+                } else {
+                    spliceIndex = insertAfter ? targetIndex + 1 : targetIndex;
+                }
+                tracker.entries.splice(spliceIndex, 0, sourceEntry);
+
+                dragSourceIndex = null;
+                await saveTracker(app, tracker, getFile(), getSectionInfo());
+            });
+        }
 
         // add copy buttons
         let buttons = element.createEl("div", { cls: "simple-time-tracker-bottom" });
@@ -409,11 +464,16 @@ function createTableSection(entry: Entry, settings: SimpleTimeTrackerSettings, i
     return ret;
 }
 
-function addEditableTableRow(app: App, tracker: Tracker, entry: Entry, table: HTMLTableElement, newSegmentNameBox: TextComponent, trackerRunning: boolean, getFile: GetFile, getSectionInfo: () => MarkdownSectionInformation, settings: SimpleTimeTrackerSettings, indent: number, component: MarkdownRenderChild): void {
+function addEditableTableRow(app: App, tracker: Tracker, entry: Entry, table: HTMLTableElement, newSegmentNameBox: TextComponent, trackerRunning: boolean, getFile: GetFile, getSectionInfo: () => MarkdownSectionInformation, settings: SimpleTimeTrackerSettings, indent: number, component: MarkdownRenderChild): HTMLTableRowElement {
     let entryRunning = getRunningEntry(tracker.entries) == entry;
     let row = table.createEl("tr");
 
     let nameField = new EditableField(row, indent, entry.name);
+    if (indent === 0) {
+        let handle = createEl("span", { cls: "simple-time-tracker-drag-handle" });
+        setIcon(handle, "grip-vertical");
+        nameField.label.prepend(handle);
+    }
     let startField = new EditableTimestampField(row, (entry.startTime), settings);
     let endField = new EditableTimestampField(row, (entry.endTime), settings);
 
@@ -539,6 +599,8 @@ function addEditableTableRow(app: App, tracker: Tracker, entry: Entry, table: HT
         for (let sub of orderedEntries(entry.subEntries, settings))
             addEditableTableRow(app, tracker, sub, table, newSegmentNameBox, trackerRunning, getFile, getSectionInfo, settings, indent + 1, component);
     }
+
+    return row;
 }
 
 function showConfirm(app: App, message: string): Promise<boolean> {

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -91,6 +91,11 @@ export function displayTracker(app: App, tracker: Tracker, element: HTMLElement,
         .setPlaceholder("Segment name")
         .setDisabled(running);
     newSegmentNameBox.inputEl.addClass("simple-time-tracker-txt");
+    newSegmentNameBox.inputEl.addEventListener("keydown", async (e: KeyboardEvent) => {
+        if (e.key !== "Enter" || running) return;
+        startNewEntry(tracker, newSegmentNameBox.getValue());
+        await saveTracker(app, tracker, getFile(), getSectionInfo());
+    });
 
     // add timers
     let timeStyle: DomElementInfo = {

--- a/styles.css
+++ b/styles.css
@@ -84,3 +84,28 @@
 .simple-time-tracker-table tr:hover {
     background-color: var(--background-modifier-hover);
 }
+
+.simple-time-tracker-drag-handle {
+    cursor: grab;
+    opacity: 0;
+    margin-right: 4px;
+    display: inline-flex;
+    vertical-align: middle;
+    transition: opacity 0.15s;
+}
+
+.simple-time-tracker-table tr:hover .simple-time-tracker-drag-handle {
+    opacity: 0.4;
+}
+
+.simple-time-tracker-row-dragging {
+    opacity: 0.4;
+}
+
+.simple-time-tracker-row-drop-before > td {
+    border-top: 2px solid var(--interactive-accent);
+}
+
+.simple-time-tracker-row-drop-after > td {
+    border-bottom: 2px solid var(--interactive-accent);
+}


### PR DESCRIPTION
Thank you very much for your super simple time tracker. It does exactly what I needed, and is beautifully executed!

However, there were two features I have wanted since I started using the plugin two years ago: 
- a faster way of starting segments, and
- the ability to reorder segments.

Reordering is useful when I forgot a segment in the middle somewhere. In the past, I'd copy a line in the source block, and then edit the line. But reordering is easier, I can just add the segment like any other, and then move it to the right place.

To implement these two features, the "new segment" text box now starts the segment on Enter. And segments can now be reordered by dragging-and-dropping. To that end, I inserted a little invisible drag handle to the left margin of each segment that only becomes visible on hover. Only the drag handle drags, the rest of the line remains editable as usual. Here's a screenshot where my mouse is hovering over the highlighted line:

<img width="901" height="307" alt="grafik" src="https://github.com/user-attachments/assets/543c034f-5f07-43a2-984e-7d5c3cbdad6b" />

Admittedly, and explicitly, these changes were written by Claude. I've tried in the past to change the super simple time tracker on my own, but typescript, web-dev, and node in particular were too much for me, so I gave up on it. For what it's worth, the code changes do look reasonable to me, and I've been running them locally without issue, so this was not a completely hands-off vibe code.

Once again, thank you for your plugin, I use it daily, and find it tremendously useful and well-designed!